### PR TITLE
Add Infinite Garble Extension mode and NoPadding

### DIFF
--- a/lib/cipher-core.js
+++ b/lib/cipher-core.js
@@ -367,6 +367,107 @@ CryptoJS.lib.Cipher || (function (undefined) {
     }());
 
     /**
+     * Infinite Garble Extension mode.
+     */
+    var IGE = C_mode.IGE = (function () {
+        /**
+         * Abstract base IGE mode.
+         */
+        var IGE = BlockCipherMode.extend();
+
+        /**
+         * IGE encryptor.
+         */
+        IGE.Encryptor = IGE.extend({
+            /**
+             * Processes the data block at offset.
+             *
+             * @param {Array} words The data words to operate on.
+             * @param {number} offset The offset where the block starts.
+             *
+             * @example
+             *
+             *     mode.processBlock(data.words, offset);
+             */
+            processBlock: function (words, offset) {
+                // Shortcuts
+                var cipher = this._cipher;
+                var blockSize = cipher.blockSize;
+
+                if (this._ivp === undefined) {
+                  this._ivp = this._iv.slice(0, blockSize);
+                  this._iv2p = this._iv.slice(blockSize, blockSize + blockSize);
+                }
+
+
+                // Remember this block to use with next block
+                var nextIv2p = words.slice(offset, offset + blockSize);
+
+                // XOR with previous ciphertext
+                xorBlock(words, this._ivp, offset, blockSize);
+
+                // Block cipher
+                cipher.encryptBlock(words, offset);
+
+                // XOR with previous plaintext
+                xorBlock(words, this._iv2p, offset, blockSize);
+
+                this._ivp = words.slice(offset, offset + blockSize);
+                this._iv2p = nextIv2p;
+            }
+        });
+
+        /**
+         * IGE decryptor.
+         */
+        IGE.Decryptor = IGE.extend({
+            /**
+             * Processes the data block at offset.
+             *
+             * @param {Array} words The data words to operate on.
+             * @param {number} offset The offset where the block starts.
+             *
+             * @example
+             *
+             *     mode.processBlock(data.words, offset);
+             */
+            processBlock: function (words, offset) {
+                // Shortcuts
+                var cipher = this._cipher;
+                var blockSize = cipher.blockSize;
+
+                if (this._ivp === undefined) {
+                  this._ivp = this._iv.slice(0, blockSize);
+                  this._iv2p = this._iv.slice(blockSize, 2 * blockSize);
+                }
+
+                // Remember this block to use with next block
+                var nextIvp = words.slice(offset, offset + blockSize);
+
+                // XOR with previous ciphertext
+                xorBlock(words, this._iv2p, offset, blockSize);
+
+                // Block cipher
+                cipher.decryptBlock(words, offset);
+
+                // XOR with previous plaintext
+                xorBlock(words, this._ivp, offset, blockSize);
+
+                this._ivp = nextIvp;
+                this._iv2p = words.slice(offset, offset + blockSize);
+            }
+        });
+
+        function xorBlock(words, block, offset, blockSize) {
+            for (var i = 0; i < blockSize; i++) {
+                words[offset + i] ^= block[i];
+            }
+        }
+
+        return IGE;
+    }());
+
+    /**
      * Padding namespace.
      */
     var C_pad = C.pad = {};
@@ -427,6 +528,15 @@ CryptoJS.lib.Cipher || (function (undefined) {
             data.sigBytes -= nPaddingBytes;
         }
     };
+
+    var NoPadding = C_pad.NoPadding = {
+        pad: function () {
+        },
+
+        unpad: function () {
+        }
+    };
+
 
     /**
      * Abstract base block cipher template.


### PR DESCRIPTION
I added Infinite Garble Extension (IGE) mode to AES and NoPadding in order to work with Telegram Messanger protocol:  https://core.telegram.org/mtproto/description 
I found this change only in Webogram project: https://github.com/zhukov/webogram/blob/master/app/vendor/cryptoJS/crypto.js
under  Jeff Mott License: https://github.com/zhukov/webogram/blob/master/app/vendor/cryptoJS/THIRDPARTY_LICENSE
